### PR TITLE
Initialize saga-flow-designer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+node_modules
+example/dist
+dist

--- a/README.md
+++ b/README.md
@@ -1,1 +1,19 @@
-# flow-designer
+# @kraldev/saga-flow-designer
+
+Lightweight BPMN-like flow designer built with React Flow, Zustand and TailwindCSS.
+
+## Install
+
+```bash
+npm install @kraldev/saga-flow-designer
+```
+
+## Usage
+
+```tsx
+import { FlowCanvas } from '@kraldev/saga-flow-designer'
+
+<FlowCanvas />
+```
+
+See `example` folder for demo using Vite.

--- a/example/index.html
+++ b/example/index.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="UTF-8" />
+    <title>Saga Flow Designer Demo</title>
+    <script type="module" src="./main.tsx"></script>
+  </head>
+  <body class="h-screen">
+    <div id="root" class="h-full"></div>
+  </body>
+</html>

--- a/example/main.tsx
+++ b/example/main.tsx
@@ -1,0 +1,12 @@
+import React from "react";
+import ReactDOM from "react-dom/client";
+import { FlowCanvas } from "../src";
+import "tailwindcss/tailwind.css";
+
+ReactDOM.createRoot(document.getElementById("root")!).render(
+  <React.StrictMode>
+    <div className="w-full h-full">
+      <FlowCanvas />
+    </div>
+  </React.StrictMode>
+);

--- a/example/tailwind.css
+++ b/example/tailwind.css
@@ -1,0 +1,3 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;

--- a/package.json
+++ b/package.json
@@ -1,0 +1,32 @@
+{
+  "name": "@kraldev/saga-flow-designer",
+  "version": "0.1.0",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "exports": {
+    ".": {
+      "import": "./dist/index.js",
+      "require": "./dist/index.js",
+      "types": "./dist/index.d.ts"
+    }
+  },
+  "scripts": {
+    "build": "tsup src/index.ts --format esm,cjs --dts --out-dir dist",
+    "dev": "vite",
+    "preview": "vite preview"
+  },
+  "dependencies": {
+    "react": "^18.0.0",
+    "react-dom": "^18.0.0",
+    "reactflow": "^11.0.0",
+    "zustand": "^4.4.0"
+  },
+  "devDependencies": {
+    "@types/react": "^18.0.0",
+    "@types/react-dom": "^18.0.0",
+    "typescript": "^5.0.0",
+    "tsup": "^7.0.0",
+    "vite": "^5.0.0",
+    "tailwindcss": "^3.0.0"
+  }
+}

--- a/postcss.config.js
+++ b/postcss.config.js
@@ -1,0 +1,6 @@
+module.exports = {
+  plugins: [
+    require('tailwindcss'),
+    require('autoprefixer'),
+  ],
+};

--- a/src/components/ConfigPanel.tsx
+++ b/src/components/ConfigPanel.tsx
@@ -1,0 +1,42 @@
+import React from "react";
+import { useFlowStore } from "../hooks/useFlowStore";
+import { Phase } from "../types";
+
+interface Props {
+  selectedPhase: Phase | null;
+  onClose: () => void;
+}
+
+export const ConfigPanel: React.FC<Props> = ({ selectedPhase, onClose }) => {
+  const { updatePhase } = useFlowStore();
+
+  if (!selectedPhase) return null;
+
+  const update = (changes: Partial<Phase>) => {
+    updatePhase({ ...selectedPhase, ...changes });
+  };
+
+  return (
+    <div className="absolute right-0 top-0 w-72 h-full bg-white shadow p-4 overflow-auto">
+      <button className="mb-2" onClick={onClose}>
+        Close
+      </button>
+      <div className="space-y-2">
+        <input
+          className="w-full border p-1"
+          value={selectedPhase.name}
+          onChange={(e) => update({ name: e.target.value })}
+        />
+        <label className="flex items-center space-x-2">
+          <input
+            type="checkbox"
+            checked={selectedPhase.isRolledback}
+            onChange={(e) => update({ isRolledback: e.target.checked })}
+          />
+          <span>Rollback</span>
+        </label>
+        {/* other config inputs can go here */}
+      </div>
+    </div>
+  );
+};

--- a/src/components/ConnectionLine.tsx
+++ b/src/components/ConnectionLine.tsx
@@ -1,0 +1,10 @@
+import React from "react";
+import { ConnectionLineComponentProps } from "reactflow";
+
+const ConnectionLine: React.FC<ConnectionLineComponentProps> = (props) => {
+  const { fromX, fromY, toX, toY } = props;
+  const path = `M${fromX},${fromY} L${toX},${toY}`;
+  return <path fill="none" stroke="#222" strokeWidth={2} d={path} />;
+};
+
+export default ConnectionLine;

--- a/src/components/FlowCanvas.tsx
+++ b/src/components/FlowCanvas.tsx
@@ -1,0 +1,42 @@
+import React from "react";
+import ReactFlow, { Background, Controls, ConnectionLineType } from "reactflow";
+import { useFlowStore } from "../hooks/useFlowStore";
+import PhaseNode from "./PhaseNode";
+import ConnectionLine from "./ConnectionLine";
+import "reactflow/dist/style.css";
+
+const nodeTypes = { phase: PhaseNode };
+
+export const FlowCanvas: React.FC = () => {
+  const { flow, setFlow } = useFlowStore();
+
+  return (
+    <div className="w-full h-full">
+      <ReactFlow
+        nodes={flow.phases.map((p) => ({
+          id: p.id,
+          type: "phase",
+          data: p,
+          position: flow.positions[p.id] || { x: 0, y: 0 },
+        }))}
+        edges={flow.phases.flatMap((p) =>
+          p.nextIds.map((n) => ({
+            id: `${p.id}-${n}`,
+            source: p.id,
+            target: n,
+            type: "default",
+          }))
+        )}
+        onNodesChange={() => {}}
+        onEdgesChange={() => {}}
+        nodeTypes={nodeTypes}
+        connectionLineComponent={ConnectionLine}
+      >
+        <Background />
+        <Controls />
+      </ReactFlow>
+    </div>
+  );
+};
+
+export default FlowCanvas;

--- a/src/components/PhaseNode.tsx
+++ b/src/components/PhaseNode.tsx
@@ -1,0 +1,23 @@
+import React from "react";
+import { Handle, Position, NodeProps } from "reactflow";
+import { Phase } from "../types";
+
+const PhaseNode: React.FC<NodeProps<Phase>> = ({ data }) => {
+  return (
+    <div
+      className={`px-4 py-2 rounded shadow-md bg-white border-2 ${{
+        grpc: "border-blue-500",
+        rest: "border-green-500",
+      }[data.type]}`}
+    >
+      <div className="font-bold text-sm mb-1 flex justify-between items-center">
+        <span>{data.name}</span>
+        <span className="text-xs bg-gray-200 px-1 rounded">{data.type}</span>
+      </div>
+      <Handle type="target" position={Position.Top} />
+      <Handle type="source" position={Position.Bottom} />
+    </div>
+  );
+};
+
+export default PhaseNode;

--- a/src/hooks/useFlowStore.ts
+++ b/src/hooks/useFlowStore.ts
@@ -1,0 +1,39 @@
+import create from "zustand";
+import { FlowDefinition, Phase } from "../types";
+import { topoSort } from "../utils/topoSort";
+
+interface FlowState {
+  flow: FlowDefinition;
+  setFlow: (flow: FlowDefinition) => void;
+  addPhase: (phase: Phase) => void;
+  updatePhase: (phase: Phase) => void;
+  removePhase: (phaseId: string) => void;
+}
+
+export const useFlowStore = create<FlowState>((set, get) => ({
+  flow: { phases: [], positions: {} },
+  setFlow: (flow) => set({ flow }),
+  addPhase: (phase) =>
+    set((state) => ({ flow: { ...state.flow, phases: [...state.flow.phases, phase] } })),
+  updatePhase: (phase) =>
+    set((state) => ({
+      flow: {
+        ...state.flow,
+        phases: state.flow.phases.map((p) => (p.id === phase.id ? phase : p)),
+      },
+    })),
+  removePhase: (id) =>
+    set((state) => ({
+      flow: {
+        ...state.flow,
+        phases: state.flow.phases.filter((p) => p.id !== id),
+      },
+    })),
+}));
+
+export function recalcSeq() {
+  const { flow, setFlow } = useFlowStore.getState();
+  const sorted = topoSort(flow.phases);
+  const phases = sorted.map((p, idx) => ({ ...p, seq: idx + 1 }));
+  setFlow({ ...flow, phases });
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,0 +1,6 @@
+export * from "./components/FlowCanvas";
+export * from "./components/ConfigPanel";
+export * from "./hooks/useFlowStore";
+export * from "./utils/flowSerializer";
+export * from "./utils/topoSort";
+export * from "./types";

--- a/src/style.css
+++ b/src/style.css
@@ -1,0 +1,3 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,0 +1,28 @@
+export type PhaseType = "grpc" | "rest";
+
+export type Phase = {
+  id: string;
+  name: string;
+  seq: number;
+  prevIds: string[];
+  nextIds: string[];
+  type: PhaseType;
+  isRolledback: boolean;
+  config: {
+    grpcServiceUrl?: string;
+    grpcMethod?: number;
+    restUrl?: string;
+    requestPropertyMap: Record<string, string>;
+    grpcRequestBody?: string;
+    grpcResponseBody?: string;
+    restRequestBody?: string;
+    restResponseBody?: string;
+  };
+};
+
+export type Positions = Record<string, { x: number; y: number }>;
+
+export type FlowDefinition = {
+  phases: Phase[];
+  positions: Positions;
+};

--- a/src/utils/flowSerializer.ts
+++ b/src/utils/flowSerializer.ts
@@ -1,0 +1,21 @@
+import { FlowDefinition, Phase } from "../types";
+
+export function exportFlow(flow: FlowDefinition): string {
+  return JSON.stringify(flow, null, 2);
+}
+
+function validateFlow(flow: FlowDefinition): void {
+  const ids = new Set<string>();
+  for (const phase of flow.phases) {
+    if (ids.has(phase.id)) {
+      throw new Error(`Duplicate phase id ${phase.id}`);
+    }
+    ids.add(phase.id);
+  }
+}
+
+export function importFlow(json: string): FlowDefinition {
+  const parsed = JSON.parse(json) as FlowDefinition;
+  validateFlow(parsed);
+  return parsed;
+}

--- a/src/utils/topoSort.ts
+++ b/src/utils/topoSort.ts
@@ -1,0 +1,25 @@
+import { Phase } from "../types";
+
+export function topoSort(phases: Phase[]): Phase[] {
+  const indegree: Record<string, number> = {};
+  const map: Record<string, Phase> = {};
+  for (const p of phases) {
+    indegree[p.id] = p.prevIds.length;
+    map[p.id] = p;
+  }
+
+  const queue: Phase[] = [];
+  phases.forEach(p => { if (indegree[p.id] === 0) queue.push(p); });
+  const sorted: Phase[] = [];
+
+  while (queue.length) {
+    const node = queue.shift()!;
+    sorted.push(node);
+    node.nextIds.forEach(nid => {
+      indegree[nid]--;
+      if (indegree[nid] === 0) queue.push(map[nid]);
+    });
+  }
+
+  return sorted;
+}

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,0 +1,11 @@
+/** @type {import('tailwindcss').Config} */
+module.exports = {
+  content: [
+    './example/**/*.{html,tsx}',
+    './src/**/*.{ts,tsx}'
+  ],
+  theme: {
+    extend: {},
+  },
+  plugins: [],
+};

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,0 +1,15 @@
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+import path from 'path';
+
+export default defineConfig({
+  plugins: [react()],
+  resolve: {
+    alias: {
+      '@': path.resolve(__dirname, './src'),
+    },
+  },
+  build: {
+    outDir: 'example/dist',
+  },
+});


### PR DESCRIPTION
## Summary
- skeleton of `@kraldev/saga-flow-designer`
- implement Phase types and utils
- add React components and Zustand store
- add Vite example and Tailwind setup
- include build scripts with tsup

## Testing
- `npm run build` *(fails: tsup not found)*

------
https://chatgpt.com/codex/tasks/task_e_6840cc60a000832ca26405647b9fbc6b